### PR TITLE
Return ts\ReflectionMethod from ts\ReflectionClass::getMethod

### DIFF
--- a/src/Reflection/ReflectionClass.php
+++ b/src/Reflection/ReflectionClass.php
@@ -118,7 +118,7 @@ class ReflectionClass
 
     public function getMethod(string $name): ReflectionMethod
     {
-        $method = $this->reflectionClass->getMethod($name);
+        return new ReflectionMethod($this->getName(), $name);
     }
 
     /**


### PR DESCRIPTION
Currently ts\ReflectionClass::getMethod isn't returning anything. I've changed it to return a ts\ReflectionMethod as per the type hint.

I made the same change to my local version and the tests for my project are now passing as expected.